### PR TITLE
Update BREAKING_CHANGES_AMENDMENTS.markdown

### DIFF
--- a/readme/BREAKING_CHANGES_AMENDMENTS.markdown
+++ b/readme/BREAKING_CHANGES_AMENDMENTS.markdown
@@ -1,3 +1,22 @@
+# 3aa30f7e03264d3798731f301853ec4f952c3637
+
+The commit message does not include the full path. The correct message should be:
+
+```
+COMMERCE-12579 Use new find method. Also rename hasDirectReplacement.
+
+# breaking
+ 
+## What commerce-product-content-api/src/main/java/com/liferay/commerce/product/content/helper/CPContentHelper.java
+
+commerce-product-content-api/src/main/java/com/liferay/commerce/product/content/helper/CPContentHelper.java has method hasDirectReplacement renamed to isDirectReplacement
+
+## Why
+
+The method now checks whether the sku is a replacement of another product rather than checking whether it has replacements
+
+```
+
 # 1063732432e7a5e5d3cf782ec1652728ef053eb9
 
 On the message of the commit 1063732432e7a5e5d3cf782ec1652728ef053eb9 the file path is not the complete path:


### PR DESCRIPTION
Hi @luca-pellizzon :

I'm working on better reporting about breaking changes in the code. A few weeks ago, Brian I. Kim commited [this breaking change](https://github.com/liferay/liferay-portal/commit/3aa30f7e03264d3798731f301853ec4f952c3637) as part of COMMERCE-12579. The message is not fully compliant with the [documentation](https://liferay.atlassian.net/wiki/spaces/ENGR/pages/2489483265/Process+to+register+breaking+changes+in+commits#The-new-process), as the indicated path is not the full path. 

In these cases, there is the need to amend the message BREAKING_CHANGES_AMENDMENTS.markdown. As Brian is on PTO I send you the change. Could you please review it and forward it?

Thank you